### PR TITLE
chore: Updated the dependency versions of kotlin and gradle build tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        //noinspection GradleDependency
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.9.5'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -43,7 +44,7 @@ ext {
     passcodeLibraryVersion = '0.3.0'
 
     // Kotlin dependencies
-    kotlinVersion = '1.3.10'
+    kotlinVersion = '1.3.50'
 
     // rxjava dependencies
     rxjavaVersion = '2.2.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 12 21:01:44 IST 2019
+#Tue Oct 15 23:46:25 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Issue: fix warning and code cleanup #51
Fixes #51 
The previous gradle build tools version 3.3.2 was causing the warning.
Changing it to 3.2.1 solved the issue