### PR TITLE
redesign: addition of CircleImageView dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$rootProject.kotlinVersion"
 
+    // Circle Image View
+    implementation 'de.hdodenhof:circleimageview:3.0.1'
+
     // Support Dependencies
     implementation "androidx.appcompat:appcompat:$rootProject.supportLibraryVersion"
     implementation "com.google.android.material:material:$rootProject.supportLibraryVersion"


### PR DESCRIPTION
## Description
I have added a CircleImageView library as it will be used in the Profile Activity and Amount Screen.

This PR has been made to avoid merge conflicts in the future. 
If this gets merged, we would be able to remove the dependency from #112 and #117 
#
- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
