### PR TITLE
Fix layout warnings

### DIFF
--- a/app/src/main/res/layout/action_bar_notification_layout.xml
+++ b/app/src/main/res/layout/action_bar_notification_layout.xml
@@ -7,19 +7,22 @@
                 android:gravity="center"
                 android:layout_gravity="center"
                 android:clickable="true"
+                android:focusable="true"
                 style="@android:style/Widget.ActionButton">
 
     <ImageView
         android:id="@+id/iv_notification_icon"
-        app:srcCompat="@drawable/ic_notifications"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:gravity="center"/>
+        android:contentDescription="@string/notification"
+        android:gravity="center"
+        app:srcCompat="@drawable/ic_notifications" />
 
     <TextView
         android:id="@+id/tv_notification_indicator"
         android:layout_width="wrap_content"
-        android:textSize="10sp"
+        android:textSize="12sp"
+        android:layout_alignEnd="@id/iv_notification_icon"
         android:paddingLeft="3dp"
         android:paddingRight="3dp"
         android:textColor="@color/white"

--- a/app/src/main/res/layout/activity_customer_profile.xml
+++ b/app/src/main/res/layout/activity_customer_profile.xml
@@ -6,7 +6,6 @@
     android:fitsSystemWindows="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         style="@style/LinearLayout.Base"
         android:background="@color/black">
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -9,7 +9,6 @@
     <include layout="@layout/toolbar"/>
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:orientation="vertical">
@@ -26,11 +25,12 @@
                 android:orientation="vertical">
 
                 <ImageView
-                    android:adjustViewBounds="true"
-                    android:layout_gravity="center"
-                    android:layout_height="@dimen/layout_padding_75dp"
                     android:layout_width="wrap_content"
-                    android:src="@drawable/mifos_logo_new"/>
+                    android:layout_height="@dimen/layout_padding_75dp"
+                    android:layout_gravity="center"
+                    android:adjustViewBounds="true"
+                    android:contentDescription="@string/copy_right_mifos"
+                    android:src="@drawable/mifos_logo_new" />
 
                 <TextView
                     android:gravity="center"
@@ -60,7 +60,8 @@
                         android:id="@+id/etUsername"
                         android:inputType="text"
                         android:layout_height="wrap_content"
-                        android:layout_width="match_parent"/>
+                        android:layout_width="match_parent"
+                        android:autofillHints="@string/username" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -78,7 +79,8 @@
                         android:id="@+id/etPassword"
                         android:inputType="textPassword"
                         android:layout_height="wrap_content"
-                        android:layout_width="match_parent"/>
+                        android:layout_width="match_parent"
+                        android:autofillHints="@string/password" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_toolbar_container.xml
+++ b/app/src/main/res/layout/activity_toolbar_container.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                  style="@style/LinearLayout.Base">
+    <LinearLayout style="@style/LinearLayout.Base">
 
-        <include layout="@layout/toolbar"/>
+        <include layout="@layout/toolbar" />
 
-        <FrameLayout
-            style="@style/FrameLayout.Container" />
+        <FrameLayout style="@style/FrameLayout.Container" />
     </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/bottom_sheet_add_debt_income.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_debt_income.xml
@@ -1,96 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <LinearLayout
-        android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:paddingBottom="@dimen/layout_padding_24dp">
 
         <LinearLayout
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <TextView
                 android:id="@+id/tv_header"
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
-                android:paddingBottom="@dimen/layout_padding_30dp"
-                android:paddingLeft="@dimen/layout_padding_24dp"
-                android:paddingRight="@dimen/layout_padding_24dp"
+                android:layout_height="match_parent"
                 android:paddingStart="@dimen/layout_padding_24dp"
+                android:paddingLeft="@dimen/layout_padding_24dp"
                 android:paddingTop="@dimen/layout_padding_24dp"
+                android:paddingRight="@dimen/layout_padding_24dp"
+                android:paddingBottom="@dimen/layout_padding_30dp"
                 android:text="@string/add_debt"
                 android:textColor="@color/colorPrimaryDark"
-                android:textStyle="bold"/>
+                android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:paddingLeft="@dimen/layout_padding_24dp"
                 android:paddingRight="@dimen/layout_padding_24dp">
 
                 <EditText
-                    android:hint="@string/amount"
                     android:id="@+id/et_amount"
-                    android:inputType="numberDecimal"
+                    android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_width="match_parent"/>
+                    android:hint="@string/amount"
+                    android:inputType="numberDecimal" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:paddingLeft="@dimen/layout_padding_24dp"
-                android:paddingRight="@dimen/layout_padding_24dp"
-                android:paddingTop="@dimen/layout_padding_16dp">
+                android:paddingTop="@dimen/layout_padding_16dp"
+                android:paddingRight="@dimen/layout_padding_24dp">
 
                 <EditText
-                    android:hint="@string/description"
                     android:id="@+id/et_description"
-                    android:inputType="textMultiLine"
-                    android:layout_height="match_parent"
                     android:layout_width="match_parent"
-                    android:scrollHorizontally="false"
-                    android:scrollbars="vertical"/>
+                    android:layout_height="match_parent"
+                    android:hint="@string/description"
+                    android:inputType="textMultiLine"
+                    android:scrollbars="vertical"
+                    android:scrollHorizontally="false" />
             </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>
 
         <LinearLayout
-            android:gravity="end"
-            android:layout_height="match_parent"
             android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="end"
             android:orientation="horizontal"
-            android:paddingBottom="@dimen/layout_padding_30dp"
-            android:paddingEnd="@dimen/layout_padding_24dp"
-            android:paddingLeft="@dimen/layout_padding_30dp"
-            android:paddingRight="@dimen/layout_padding_24dp"
             android:paddingStart="@dimen/layout_padding_30dp"
-            android:paddingTop="@dimen/layout_padding_16dp">
+            android:paddingLeft="@dimen/layout_padding_30dp"
+            android:paddingTop="@dimen/layout_padding_16dp"
+            android:paddingEnd="@dimen/layout_padding_24dp"
+            android:paddingRight="@dimen/layout_padding_24dp"
+            android:paddingBottom="@dimen/layout_padding_30dp">
 
             <Button
                 android:id="@+id/btn_cancel"
-                android:layout_gravity="center"
+                style="?android:attr/borderlessButtonStyle"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:layout_marginEnd="@dimen/layout_padding_16dp"
                 android:layout_marginRight="@dimen/layout_padding_16dp"
-                android:layout_width="wrap_content"
                 android:text="@string/cancel"
-                android:textAllCaps="false"/>
+                android:textAllCaps="false" />
 
             <Button
                 android:id="@+id/btn_add_debt_income"
-                android:layout_gravity="center"
-                android:layout_height="wrap_content"
+                style="?android:attr/borderlessButtonStyle"
                 android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:text="@string/add_debt"
-                android:textAllCaps="false"
-            />
+                android:textAllCaps="false" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -37,6 +37,7 @@
             android:layout_height="148dp"
             android:layout_gravity="center"
             android:layout_margin="@dimen/layout_padding_16dp"
+            android:contentDescription="@string/copy_right_mifos"
             android:src="@drawable/mifos_logo_new" />
 
         <TextView

--- a/app/src/main/res/layout/fragment_accounts.xml
+++ b/app/src/main/res/layout/fragment_accounts.xml
@@ -7,7 +7,6 @@
     android:layout_width="match_parent">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/swipe_container"
         android:layout_height="match_parent"
         android:layout_width="match_parent">

--- a/app/src/main/res/layout/fragment_client_accounts.xml
+++ b/app/src/main/res/layout/fragment_client_accounts.xml
@@ -33,6 +33,7 @@
         android:visibility="gone"
         android:id="@+id/fab_create_loan"
         app:layout_behavior="org.mifos.mobile.cn.ui.utils.ScrollFabBehaviour"
-        app:srcCompat="@drawable/ic_add_white_24dp"/>
+        app:srcCompat="@drawable/ic_add_white_24dp"
+        android:focusable="true" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_customer_deposit_details.xml
+++ b/app/src/main/res/layout/fragment_customer_deposit_details.xml
@@ -10,8 +10,6 @@
     android:visibility="invisible">
 
     <androidx.cardview.widget.CardView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/white"
         android:clickable="true"
         android:foreground="?android:attr/selectableItemBackground"
@@ -19,7 +17,8 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:visibility="visible"
-        app:cardElevation="4dp">
+        app:cardElevation="4dp"
+        android:focusable="true">
 
         <LinearLayout
             android:layout_height="match_parent"
@@ -53,7 +52,8 @@
                         android:id="@+id/iv_deposit_current_status"
                         android:layout_height="35dp"
                         android:layout_width="35dp"
-                        app:srcCompat="@drawable/ic_check_circle_black_24dp"/>
+                        app:srcCompat="@drawable/ic_check_circle_black_24dp"
+                        android:contentDescription="@string/approved" />
 
                     <TextView
                         android:foregroundGravity="center"
@@ -102,7 +102,8 @@
                         android:layout_gravity="center"
                         android:layout_height="35dp"
                         android:layout_width="35dp"
-                        app:srcCompat="@drawable/ic_account_balance_black_24dp"/>
+                        app:srcCompat="@drawable/ic_account_balance_black_24dp"
+                        android:contentDescription="@string/balance" />
 
                     <LinearLayout
                         android:layout_height="wrap_content"
@@ -141,7 +142,8 @@
                         android:layout_gravity="center"
                         android:layout_height="35dp"
                         android:layout_width="35dp"
-                        app:srcCompat="@drawable/ic_account_balance_wallet_black_24dp"/>
+                        app:srcCompat="@drawable/ic_account_balance_wallet_black_24dp"
+                        android:contentDescription="@string/balance" />
 
                     <LinearLayout
                         android:layout_height="wrap_content"
@@ -179,7 +181,8 @@
                         android:layout_gravity="center"
                         android:layout_height="35dp"
                         android:layout_width="35dp"
-                        app:srcCompat="@drawable/ic_people_black_24dp"/>
+                        app:srcCompat="@drawable/ic_people_black_24dp"
+                        android:contentDescription="@string/username" />
 
                     <LinearLayout
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_customer_loan_details.xml
+++ b/app/src/main/res/layout/fragment_customer_loan_details.xml
@@ -9,8 +9,6 @@
     android:orientation="vertical">
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/gray_light"
         android:id="@+id/ncv_customer_loan_details"
         android:layout_height="match_parent"
@@ -26,15 +24,14 @@
 
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:clickable="true"
                 android:foreground="?android:attr/selectableItemBackground"
                 android:id="@+id/cv_customer"
                 android:layout_height="match_parent"
                 android:layout_width="match_parent"
-                android:visibility="visible">
+                android:visibility="visible"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_height="match_parent"
@@ -68,7 +65,8 @@
                                 android:id="@+id/iv_loan_current_status"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_check_circle_black_24dp"/>
+                                app:srcCompat="@drawable/ic_check_circle_black_24dp"
+                                android:contentDescription="@string/current_status" />
 
                             <TextView
                                 android:foregroundGravity="center"
@@ -117,7 +115,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_account_balance_black_24dp"/>
+                                app:srcCompat="@drawable/ic_account_balance_black_24dp"
+                                android:contentDescription="@string/balance" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -156,7 +155,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_access_time_black_24dp"/>
+                                app:srcCompat="@drawable/ic_access_time_black_24dp"
+                                android:contentDescription="@string/payment_cycle" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -194,7 +194,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_event_black_24dp"/>
+                                app:srcCompat="@drawable/ic_event_black_24dp"
+                                android:contentDescription="@string/term" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -340,8 +341,6 @@
                 android:text="@string/management"/>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:id="@+id/cv_management"
                 android:layout_height="match_parent"
@@ -359,7 +358,8 @@
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"
                         android:orientation="horizontal"
-                        android:padding="16dp">
+                        android:padding="16dp"
+                        android:focusable="true">
 
                         <LinearLayout
                             android:layout_height="wrap_content"
@@ -371,7 +371,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_payment_black_24dp"/>
+                                app:srcCompat="@drawable/ic_payment_black_24dp"
+                                android:contentDescription="@string/planned_payment" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -405,7 +406,8 @@
                         android:layout_height="match_parent"
                         android:layout_width="match_parent"
                         android:orientation="horizontal"
-                        android:padding="16dp">
+                        android:padding="16dp"
+                        android:focusable="true">
 
                         <LinearLayout
                             android:layout_height="wrap_content"
@@ -417,7 +419,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_task_black_24dp"/>
+                                app:srcCompat="@drawable/ic_task_black_24dp"
+                                android:contentDescription="@string/tasks" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -451,7 +454,8 @@
                         android:layout_height="match_parent"
                         android:layout_width="match_parent"
                         android:orientation="horizontal"
-                        android:padding="@dimen/layout_padding_16dp">
+                        android:padding="@dimen/layout_padding_16dp"
+                        android:focusable="true">
 
                         <LinearLayout
                             android:layout_height="wrap_content"
@@ -463,7 +467,8 @@
                                 android:layout_gravity="center"
                                 android:layout_height="35dp"
                                 android:layout_width="35dp"
-                                app:srcCompat="@drawable/ic_show_chart_black_24dp"/>
+                                app:srcCompat="@drawable/ic_show_chart_black_24dp"
+                                android:contentDescription="@string/debt_income_report" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -34,14 +34,16 @@
 
                     <ImageView
                         android:id="@+id/iv_user_image"
-                        android:layout_gravity="center"
-                        android:layout_height="65dp"
-                        android:layout_margin="@dimen/margin_16dp"
                         android:layout_width="65dp"
-                        android:visibility="visible"
+                        android:layout_height="65dp"
+                        android:layout_gravity="center"
+                        android:layout_margin="@dimen/margin_16dp"
                         android:background="?selectableItemBackgroundBorderless"
                         android:clickable="true"
-                        app:srcCompat="@drawable/ic_person_black_24dp"/>
+                        android:focusable="true"
+                        android:contentDescription="@string/customer_image"
+                        android:visibility="visible"
+                        app:srcCompat="@drawable/ic_person_black_24dp" />
 
                     <org.mifos.mobile.cn.ui.utils.CircularImageView
                         android:id="@+id/iv_circular_user_image"
@@ -52,6 +54,7 @@
                         android:visibility="gone"
                         android:background="?selectableItemBackgroundBorderless"
                         android:clickable="true"
+                        android:focusable="true"
                         tools:src="@drawable/ic_person_black_24dp"/>
 
                     <TextView
@@ -77,6 +80,7 @@
 
                     <LinearLayout
                         android:clickable="true"
+                        android:focusable="true"
                         android:foreground="?selectableItemBackground"
                         android:id="@+id/ll_account_overview"
                         android:layout_height="match_parent"
@@ -110,6 +114,7 @@
                                 android:layout_alignParentEnd="true"
                                 android:layout_alignParentRight="true"
                                 android:layout_centerInParent="true"
+                                android:contentDescription="@string/account_overview"
                                 android:tint="@color/white"
                                 app:srcCompat="@drawable/ic_keyboard_arrow_right_black_24dp" />
 
@@ -119,6 +124,7 @@
 
                     <LinearLayout
                         android:clickable="true"
+                        android:focusable="true"
                         android:foreground="?selectableItemBackground"
                         android:id="@+id/ll_recent_transactions"
                         android:layout_height="match_parent"
@@ -146,13 +152,14 @@
                                 android:textSize="14sp"/>
 
                             <ImageView
+                                android:layout_width="wrap_content"
+                                android:layout_height="match_parent"
                                 android:layout_alignParentEnd="true"
                                 android:layout_alignParentRight="true"
                                 android:layout_centerInParent="true"
-                                android:layout_height="match_parent"
-                                android:layout_width="wrap_content"
+                                android:contentDescription="@string/recent_transactions"
                                 android:tint="@color/white"
-                                app:srcCompat="@drawable/ic_keyboard_arrow_right_black_24dp"/>
+                                app:srcCompat="@drawable/ic_keyboard_arrow_right_black_24dp" />
 
                         </RelativeLayout>
 
@@ -194,6 +201,7 @@
                         <LinearLayout
                             android:background="?selectableItemBackgroundBorderless"
                             android:clickable="true"
+                            android:focusable="true"
                             android:gravity="center"
                             android:id="@+id/ll_accounts"
                             android:layout_height="wrap_content"
@@ -213,14 +221,15 @@
                                 app:cardCornerRadius="30dp">
 
                                 <ImageView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="60dp"
                                     android:layout_alignParentTop="true"
                                     android:layout_centerHorizontal="true"
                                     android:layout_gravity="center"
-                                    android:layout_height="60dp"
-                                    android:layout_width="wrap_content"
+                                    android:contentDescription="@string/accounts"
                                     android:padding="@dimen/layout_padding_16dp"
                                     android:tint="@color/white"
-                                    app:srcCompat="@drawable/ic_account_balance_black_24dp"/>
+                                    app:srcCompat="@drawable/ic_account_balance_black_24dp" />
 
                             </androidx.cardview.widget.CardView>
 
@@ -242,6 +251,7 @@
                         <LinearLayout
                             android:background="?selectableItemBackgroundBorderless"
                             android:clickable="true"
+                            android:focusable="true"
                             android:gravity="center"
                             android:id="@+id/ll_transfer"
                             android:layout_height="wrap_content"
@@ -291,6 +301,7 @@
                         <LinearLayout
                             android:background="?selectableItemBackgroundBorderless"
                             android:clickable="true"
+                            android:focusable="true"
                             android:gravity="center"
                             android:id="@+id/ll_apply_for_loan"
                             android:layout_height="wrap_content"
@@ -371,6 +382,7 @@
                         <LinearLayout
                             android:background="?selectableItemBackgroundBorderless"
                             android:clickable="true"
+                            android:focusable="true"
                             android:gravity="center"
                             android:id="@+id/ll_beneficiaries"
                             android:layout_height="wrap_content"
@@ -468,6 +480,7 @@
                         <LinearLayout
                             android:background="?selectableItemBackgroundBorderless"
                             android:clickable="true"
+                            android:focusable="true"
                             android:gravity="center"
                             android:id="@+id/ll_surveys"
                             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_debt_income_report.xml
+++ b/app/src/main/res/layout/fragment_debt_income_report.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent">
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/gray_light"
         android:id="@+id/ncv_customer_details"
@@ -32,7 +31,6 @@
                 android:text="@string/total_debt"/>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:id="@+id/cv_financial_products"
@@ -47,24 +45,23 @@
                     android:orientation="vertical">
 
                     <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
                         android:clickable="true"
-                        android:foreground="?android:attr/selectableItemBackground"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"
                         android:orientation="vertical"
                         android:paddingLeft="@dimen/layout_padding_16dp"
                         android:paddingRight="@dimen/layout_padding_16dp"
-                        android:paddingTop="@dimen/layout_padding_8dp">
+                        android:paddingTop="@dimen/layout_padding_8dp"
+                        android:focusable="true">
 
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
                             android:clickable="true"
                             android:foreground="?android:attr/selectableItemBackground"
                             android:id="@+id/ll_customer_deposit_accounts"
                             android:layout_height="wrap_content"
                             android:layout_width="match_parent"
-                            android:orientation="horizontal">
+                            android:orientation="horizontal"
+                            android:focusable="true">
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -127,7 +124,6 @@
                 android:text="@string/total_income"/>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:layout_height="match_parent"
@@ -141,7 +137,6 @@
                     android:orientation="vertical">
 
                     <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
                         android:clickable="true"
                         android:foreground="?android:attr/selectableItemBackground"
                         android:layout_height="wrap_content"
@@ -149,15 +144,16 @@
                         android:orientation="vertical"
                         android:paddingLeft="@dimen/layout_padding_16dp"
                         android:paddingRight="@dimen/layout_padding_16dp"
-                        android:paddingTop="@dimen/layout_padding_8dp">
+                        android:paddingTop="@dimen/layout_padding_8dp"
+                        android:focusable="true">
 
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
                             android:clickable="true"
                             android:foreground="?android:attr/selectableItemBackground"
                             android:layout_height="wrap_content"
                             android:layout_width="match_parent"
-                            android:orientation="horizontal">
+                            android:orientation="horizontal"
+                            android:focusable="true">
 
                             <LinearLayout
                                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_identification_details.xml
+++ b/app/src/main/res/layout/fragment_identification_details.xml
@@ -10,8 +10,6 @@
     android:visibility="visible">
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/gray_light"
         android:id="@+id/ncv_customer_loan_details"
         android:layout_height="match_parent"
@@ -25,10 +23,9 @@
             android:paddingBottom="@dimen/layout_padding_64dp">
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:clickable="true"
+                android:focusable="true"
                 android:foreground="?android:attr/selectableItemBackground"
                 android:id="@+id/cv_customer"
                 android:layout_height="match_parent"
@@ -111,12 +108,13 @@
                             android:orientation="horizontal">
 
                             <ImageView
-                                android:baselineAlignBottom="true"
-                                android:layout_gravity="center"
-                                android:layout_height="30dp"
-                                android:layout_marginTop="@dimen/layout_padding_4dp"
                                 android:layout_width="30dp"
-                                app:srcCompat="@drawable/ic_event_black_24dp"/>
+                                android:layout_height="30dp"
+                                android:layout_gravity="center"
+                                android:layout_marginTop="@dimen/layout_padding_4dp"
+                                android:baselineAlignBottom="true"
+                                android:contentDescription="@string/expiration_date"
+                                app:srcCompat="@drawable/ic_event_black_24dp" />
 
                             <LinearLayout
                                 android:layout_height="wrap_content"
@@ -189,15 +187,12 @@
                 android:text="@string/scans_uploaded"/>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:id="@+id/cv_scans_uploaded"
                 android:layout_height="match_parent"
                 android:layout_width="match_parent">
 
                 <FrameLayout
-                    xmlns:android="http://schemas.android.com/apk/res/android"
                     android:layout_height="match_parent"
                     android:layout_width="match_parent">
 

--- a/app/src/main/res/layout/fragment_loan_co_signer.xml
+++ b/app/src/main/res/layout/fragment_loan_co_signer.xml
@@ -6,7 +6,6 @@
     android:orientation="vertical">
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/gray_light"
         android:id="@+id/ncv_customer_details"
@@ -22,7 +21,6 @@
             android:paddingTop="@dimen/layout_padding_8dp">
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_loan_debt_income_ratio.xml
+++ b/app/src/main/res/layout/fragment_loan_debt_income_ratio.xml
@@ -6,7 +6,6 @@
     android:orientation="vertical">
 
     <androidx.core.widget.NestedScrollView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/gray_light"
         android:id="@+id/ncv_customer_details"
@@ -34,7 +33,6 @@
                 android:text="@string/ratio"/>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:id="@+id/cv_financial_products"
@@ -50,6 +48,7 @@
 
                     <RelativeLayout
                         android:clickable="true"
+                        android:focusable="true"
                         android:foreground="?android:attr/selectableItemBackground"
                         android:id="@+id/ll_loan_accounts"
                         android:layout_height="wrap_content"
@@ -115,7 +114,6 @@
             </androidx.cardview.widget.CardView>
 
             <androidx.cardview.widget.CardView
-                xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:layout_height="wrap_content"
@@ -131,6 +129,7 @@
 
                     <RelativeLayout
                         android:clickable="true"
+                        android:focusable="true"
                         android:foreground="?android:attr/selectableItemBackground"
                         android:layout_height="wrap_content"
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_view_scan_card.xml
+++ b/app/src/main/res/layout/fragment_view_scan_card.xml
@@ -8,12 +8,12 @@
 
     <ImageView
         android:id="@+id/iv_scan_card"
-        android:adjustViewBounds="true"
-        android:layout_gravity="center"
-        android:layout_height="match_parent"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/identification_cards"
         android:scaleType="fitCenter"
-        android:visibility="visible"
-        />
+        android:visibility="visible" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_customer_activities.xml
+++ b/app/src/main/res/layout/item_customer_activities.xml
@@ -8,10 +8,10 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:orientation="vertical"
-    android:paddingTop="@dimen/layout_padding_8dp">
+    android:paddingTop="@dimen/layout_padding_8dp"
+    android:focusable="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/linearLayout"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_debt_income_report.xml
+++ b/app/src/main/res/layout/item_debt_income_report.xml
@@ -8,16 +8,17 @@
     android:orientation="vertical"
     android:paddingLeft="@dimen/layout_padding_16dp"
     android:paddingRight="@dimen/layout_padding_16dp"
-    android:paddingTop="@dimen/layout_padding_8dp">
+    android:paddingTop="@dimen/layout_padding_8dp"
+    android:focusable="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:clickable="true"
         android:foreground="?android:attr/selectableItemBackground"
         android:id="@+id/ll_customer_deposit_accounts"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:focusable="true">
 
         <LinearLayout
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_header_planned_payment.xml
+++ b/app/src/main/res/layout/item_header_planned_payment.xml
@@ -9,8 +9,6 @@
     android:visibility="visible">
 
     <androidx.cardview.widget.CardView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/white"
         android:id="@+id/cv_customer_deposit_details"
         android:layout_height="wrap_content"
@@ -36,11 +34,12 @@
                 android:padding="16dp">
 
                 <ImageView
-                    android:layout_gravity="center"
-                    android:layout_height="30dp"
                     android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@string/customer_image"
                     android:tint="@color/colorPrimary"
-                    app:srcCompat="@drawable/ic_perm_contact_calendar_black_24dp"/>
+                    app:srcCompat="@drawable/ic_perm_contact_calendar_black_24dp" />
 
                 <LinearLayout
                     android:layout_height="wrap_content"
@@ -72,13 +71,15 @@
 
                     <ImageView
                         android:id="@+id/iv_collapse"
-                        android:layout_gravity="center"
-                        android:layout_height="30dp"
                         android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_gravity="center"
                         android:clickable="true"
-                        android:tint="@color/collapse_image"
+                        android:focusable="true"
+                        android:contentDescription="@string/open_drawer"
                         android:foreground="?android:attr/selectableItemBackground"
-                        app:srcCompat="@drawable/ic_arrow_drop_up_black_24dp"/>
+                        android:tint="@color/collapse_image"
+                        app:srcCompat="@drawable/ic_arrow_drop_up_black_24dp" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/item_identification.xml
+++ b/app/src/main/res/layout/item_identification.xml
@@ -8,10 +8,10 @@
     android:foreground="?android:attr/selectableItemBackground"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:baselineAligned="false"
         android:id="@+id/ll_identifier_card"
         android:layout_height="wrap_content"
@@ -19,7 +19,8 @@
         android:clickable="true"
         android:foreground="?android:attr/selectableItemBackground"
         android:minHeight="?attr/listPreferredItemHeight"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:focusable="true">
 
         <LinearLayout
             android:layout_height="match_parent"
@@ -36,10 +37,11 @@
 
                 <ImageView
                     android:id="@+id/iv_task1"
-                    android:layout_height="wrap_content"
                     android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/identification_cards"
                     android:tint="@color/icon_color"
-                    app:srcCompat="@drawable/ic_description_black_24dp"/>
+                    app:srcCompat="@drawable/ic_description_black_24dp" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/item_identification_scan_card.xml
+++ b/app/src/main/res/layout/item_identification_scan_card.xml
@@ -8,10 +8,10 @@
     android:foreground="?android:attr/selectableItemBackground"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="true">
 
     <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:baselineAligned="false"
         android:clickable="true"
         android:foreground="?android:attr/selectableItemBackground"
@@ -19,7 +19,8 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:minHeight="?attr/listPreferredItemHeight"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:focusable="true">
 
         <LinearLayout
             android:layout_height="match_parent"
@@ -36,10 +37,11 @@
 
                 <ImageView
                     android:id="@+id/iv_task1"
-                    android:layout_height="wrap_content"
                     android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/identification_cards"
                     android:tint="@color/icon_color"
-                    app:srcCompat="@drawable/ic_description_black_24dp"/>
+                    app:srcCompat="@drawable/ic_description_black_24dp" />
 
             </LinearLayout>
 
@@ -74,7 +76,8 @@
                     android:layout_weight="0.5"
                     android:clickable="true"
                     android:foreground="?android:attr/selectableItemBackground"
-                    android:layout_width="wrap_content">
+                    android:layout_width="wrap_content"
+                    android:focusable="true">
 
 
                 </LinearLayout>

--- a/app/src/main/res/layout/item_loan_debt_income.xml
+++ b/app/src/main/res/layout/item_loan_debt_income.xml
@@ -66,7 +66,7 @@
                     android:contentDescription="@string/debt_income_edit_image"
                     android:foreground="?android:attr/selectableItemBackground"
                     app:srcCompat="@drawable/ic_edit_black_24dp"
-                />
+                    android:focusable="true" />
 
                 <ImageView
                     android:id="@+id/iv_delete"
@@ -78,7 +78,8 @@
                     android:clickable="true"
                     android:contentDescription="@string/debt_income_delete_image"
                     android:foreground="?android:attr/selectableItemBackground"
-                    app:srcCompat="@drawable/ic_delete_black_24dp"/>
+                    app:srcCompat="@drawable/ic_delete_black_24dp"
+                    android:focusable="true" />
             </LinearLayout>
 
 

--- a/app/src/main/res/layout/item_panned_payment.xml
+++ b/app/src/main/res/layout/item_panned_payment.xml
@@ -8,10 +8,10 @@
     android:orientation="vertical">
 
     <androidx.cardview.widget.CardView
-        xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:background="@color/white"
         android:clickable="true"
+        android:focusable="true"
         android:foreground="?android:attr/selectableItemBackground"
         android:id="@+id/cv_customer_deposit_details"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_product.xml
+++ b/app/src/main/res/layout/item_product.xml
@@ -7,7 +7,8 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:foreground="?android:attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="true">
 
     <LinearLayout
         android:id="@+id/ll_product"

--- a/app/src/main/res/layout/item_recent_transactions.xml
+++ b/app/src/main/res/layout/item_recent_transactions.xml
@@ -7,7 +7,8 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:foreground="?android:attr/selectableItemBackground"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:focusable="true">
 
     <LinearLayout
         android:id="@+id/ll_recent_transactions"

--- a/app/src/main/res/layout/nav_drawer_header.xml
+++ b/app/src/main/res/layout/nav_drawer_header.xml
@@ -11,18 +11,20 @@
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <ImageView
-        android:background="?selectableItemBackgroundBorderless"
-        android:clickable="true"
-        android:focusable="true"
         android:id="@+id/iv_user_image"
+        android:layout_width="65dp"
         android:layout_height="65dp"
         android:layout_marginTop="20dp"
-        android:layout_width="65dp"
-        app:srcCompat="@drawable/ic_person_black_24dp"/>
+        android:background="?selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:contentDescription="@string/customer_image"
+        android:focusable="true"
+        app:srcCompat="@drawable/ic_person_black_24dp" />
 
     <org.mifos.mobile.cn.ui.utils.CircularImageView
         android:background="?selectableItemBackgroundBorderless"
         android:clickable="true"
+        android:focusable="true"
         android:id="@+id/iv_circular_user_image"
         android:layout_height="65dp"
         android:layout_marginTop="20dp"

--- a/app/src/main/res/layout/row_checkbox.xml
+++ b/app/src/main/res/layout/row_checkbox.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="horizontal"
-              android:layout_width="match_parent"
-              android:clickable="true"
-              android:id="@+id/ll_row_checkbox"
-              android:background="?selectableItemBackground"
-              android:paddingLeft="@dimen/default_margin"
-              android:paddingStart="@dimen/default_margin"
-              android:paddingRight="@dimen/default_margin"
-              android:paddingEnd="@dimen/default_margin"
-              android:layout_height="wrap_content">
+    android:id="@+id/ll_row_checkbox"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/default_margin"
+    android:paddingLeft="@dimen/default_margin"
+    android:paddingEnd="@dimen/default_margin"
+    android:paddingRight="@dimen/default_margin">
+
     <androidx.appcompat.widget.AppCompatCheckBox
+        android:id="@+id/cb_status_select"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/cb_status_select"
-        android:layout_margin="@dimen/margin_4dp"/>
+        android:layout_margin="@dimen/margin_4dp" />
 
     <TextView
         android:id="@+id/tv_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_4dp"
         android:text="@string/small_text"
-        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-        android:layout_margin="@dimen/margin_4dp"/>
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
 </LinearLayout>


### PR DESCRIPTION
Fixes #127 

**The below warnings were ignored** 

> Attribute android:foreground has no effect on API levels lower than 23 (current min is 16)

- This warning is not solvable due to a bug which is existing since API 23 [[1]](https://issuetracker.google.com/issues/37065042?enable_mat=true)


> Overlapping items in RelativeLayout

- Fixing this requires using margins which will change the layout majorly and the changes are it visually pleasing either



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
