### PR TITLE
fixes : #129 (Image is not aligned in center in Nagivation Drawer)

### DIFF
--- a/app/src/main/res/layout/nav_drawer_header.xml
+++ b/app/src/main/res/layout/nav_drawer_header.xml
@@ -18,6 +18,7 @@
         android:layout_height="65dp"
         android:layout_marginTop="20dp"
         android:layout_width="65dp"
+        android:layout_gravity="center"
         app:srcCompat="@drawable/ic_person_black_24dp"/>
 
     <org.mifos.mobile.cn.ui.utils.CircularImageView


### PR DESCRIPTION
Fixes #129 

Please Add Screenshots If there are any UI changes.
Image aligned in center in Navigation Drawer.
![Screenshot_20200208-132316_mifos-mobile-cn](https://user-images.githubusercontent.com/22510309/74081782-d0edd580-4a78-11ea-8ba8-5f90dcf7d693.jpg)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
