### PR TITLE
fix: Change permission from CAMERA to WRITE EXTERNAL STORAGE

### DIFF
--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/customerProfile/CustomerProfileActivity.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/customerProfile/CustomerProfileActivity.kt
@@ -43,7 +43,7 @@ class CustomerProfileActivity: MifosBaseActivity(),CustomerProfileContract.View 
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.menu_customer_profile_share) {
-            checkCameraPermission()
+            checkWriteExternalStoragePermission()
             return true
         }
         else return super.onOptionsItemSelected(item)
@@ -79,7 +79,7 @@ class CustomerProfileActivity: MifosBaseActivity(),CustomerProfileContract.View 
         return returnedBitmap
     }
 
-    override fun checkCameraPermission() {
+    override fun checkWriteExternalStoragePermission() {
         if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
                         android.Manifest.permission.WRITE_EXTERNAL_STORAGE)){
             shareImage()
@@ -110,7 +110,7 @@ class CustomerProfileActivity: MifosBaseActivity(),CustomerProfileContract.View 
    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>,
                                    grantResults: IntArray) {
         when (requestCode) {
-            ConstantKeys.PERMISSIONS_REQUEST_CAMERA -> {
+            ConstantKeys.PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE -> {
                 if (grantResults.size > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     shareImage()
                 } else {

--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/customerProfile/CustomerProfileContract.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/customerProfile/CustomerProfileContract.kt
@@ -5,7 +5,7 @@ import org.mifos.mobile.cn.ui.base.MvpView
 interface CustomerProfileContract {
 
     interface View: MvpView{
-        fun checkCameraPermission();
+        fun checkWriteExternalStoragePermission();
 
         fun requestPermission();
 


### PR DESCRIPTION
Fixes #141 

**Summary**
Changed permission from CAMERA to WRITE EXTERNAL STORAGE when clicked on "share" in appbar in CustomerProfileActivity.

**Observed Behaviour**
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/31249460/77195410-96f80080-6b07-11ea-99ae-f361c0313b2a.gif)


**Expected Behaviour**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/31249460/77195020-f7d30900-6b06-11ea-82ac-ab10837c23da.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
