### PR TITLE
fix: Handle invalid login credentials

### DIFF
--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/login/LoginActivity.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/login/LoginActivity.kt
@@ -63,8 +63,9 @@ class LoginActivity : MifosBaseActivity(), LoginContract.View, View.OnClickListe
             etPassword.error = "Password required"
             return
         }
-        loginPresenter.login(username, password)
         Toaster.show(findViewById(android.R.id.content), getString(R.string.logging_in), Toaster.SHORT)
+        loginPresenter.login(username, password)
+
     }
 
 
@@ -96,6 +97,6 @@ class LoginActivity : MifosBaseActivity(), LoginContract.View, View.OnClickListe
     }
     override fun showUserLoginUnSuccessfully(){
       preferencesHelper.putLoginStatus(false)
-        Toast.makeText(this,"Invalid Credentials",Toast.LENGTH_SHORT).show()
+        Toaster.show(findViewById(android.R.id.content), getString(R.string.invalid_credentials), Toaster.SHORT)
     }
 }

--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/login/LoginPresenter.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/login/LoginPresenter.kt
@@ -19,16 +19,15 @@ constructor(@ApplicationContext context: Context) :
         checkViewAttached()
         getMvpView.showProgress()
         if (isCredentialValid(username, password)) {
-            getMvpView.hideProgress()
             if (preferencesHelper.password.equals(password)
                     && preferencesHelper.username.equals(username)) {
                 getMvpView.showUserLoginSuccessfully()
             } else {
-                getMvpView.hideProgress()
                 getMvpView.showUserLoginUnSuccessfully()
             }
 
         }
+        getMvpView.hideProgress()
     }
 
     override fun attachView(mvpView: LoginContract.View) {

--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/utils/Toaster.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/utils/Toaster.kt
@@ -28,6 +28,7 @@ object Toaster {
         textView.maxLines = 5
         snackbar.setAction("OK") { snackbar.dismiss() }
         snackbar.show()
+        hideSnackbad =  snackbar
     }
 
     fun showProgressMessage(view: View, text: String, duration: Int) {
@@ -45,7 +46,7 @@ object Toaster {
         try {
             hideSnackbad!!.dismiss()
         } catch (e: NullPointerException) {
-            Log.d(LOG_TAG, e.localizedMessage)
+            Log.d(LOG_TAG, e.toString())
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,7 @@
     <string name="privacy_policy_host" translatable="false">openmf.github.io/privacy_policy_mifos_mobile.html</string>
     <string name="privacy_policy_host_url" translatable="false">https://openmf.github.io/privacy_policy_mifos_mobile.html</string>
     <string name="opensource_license_title">Open Source licenses</string>
+    <string name="invalid_credentials">Invalid Credentials</string>
 
 
 </resources>


### PR DESCRIPTION
Fixes #163 

**Summary**
Hide progress bar after invalid wrong credentials entered.

**Observed Behaviour**
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/31249460/77244443-d6733980-6c3a-11ea-8c15-b796527c7eb8.gif)


**Expected Behaviour**
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/31249460/77244436-cb200e00-6c3a-11ea-8854-3ac00e5ea710.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
