### PR TITLE
Fix #108: Restrict rotation in login and passcode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,8 +24,10 @@
         </activity>
 
         <activity android:name=".ui.mifos.DashboardActivity" />
-        <activity android:name=".ui.mifos.login.LoginActivity" />
-        <activity android:name=".ui.mifos.passcode.PasscodeActivity"/>
+        <activity android:name=".ui.mifos.login.LoginActivity"
+            android:screenOrientation="portrait"/>
+        <activity android:name=".ui.mifos.passcode.PasscodeActivity"
+            android:screenOrientation="portrait"/>
         <activity android:name=".ui.mifos.loanApplication.loanActivity.LoanApplicationActivity"/>
         <activity android:name=".ui.mifos.customerDetails.CustomerDetailsActivity"/>
         <activity android:name=".ui.mifos.customerActivities.CustomerActivitiesActivity"/>


### PR DESCRIPTION
## Issue Fix
Fixes #108 

## Screenshots 

(Device: Asus X01BDA | ROM: OxygenOS 10)
<img src="https://raw.githubusercontent.com/ashwinkey04/temp/master/assets/1.jpg" width = "250">

## Description
Screen orientation is restricted to portrait for `LoginActivity` and `PasscodeActivity`

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
