### PR TITLE
fixed #170 Useless profile icon multiple times

### DIFF
--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/DashboardActivity.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/DashboardActivity.kt
@@ -32,6 +32,7 @@ import org.mifos.mobile.cn.ui.utils.CircularImageView
 import org.mifos.mobile.cn.ui.utils.Toaster
 import android.widget.Toast
 import com.mifos.mobile.passcode.utils.PasscodePreferencesHelper
+import org.mifos.mobile.cn.ui.mifos.customerDetails.CustomerDetailsFragment
 import org.mifos.mobile.cn.ui.mifos.passcode.PasscodeActivity
 import org.mifos.mobile.cn.ui.utils.ConstantKeys
 
@@ -137,8 +138,20 @@ class DashboardActivity : MifosBaseActivity(), View.OnClickListener, NavigationV
         ivCircularUserProfilePicture.setOnClickListener(this)
     }
 
-    override fun onClick(v: View) {
+    override fun onClick(view: View?) {
         // Click Header to view full profile of User
+
+        when(view?.id) {
+            R.id.iv_circular_user_image->{
+                replaceFragment(CustomerDetailsFragment.newInstance("customer_identifier"), true,
+                        R.id.container)
+
+            }
+            R.id.iv_user_image->{
+                replaceFragment(CustomerDetailsFragment.newInstance("customer_identifier"), true,
+                        R.id.container)
+            }
+        }
     }
 
     private fun setUpBackStackListener() {


### PR DESCRIPTION
## Issue Fix
Fixes #170 

## Short Video

https://user-images.githubusercontent.com/72181295/105945306-0e34e400-608b-11eb-8af1-f47660db896f.mp4


<!--Please Add Screenshots or Screen Recordings which show the changes that you made.-->

## Description
Creating onClick method for ivTextDrawableUserProfilePicture.setOnClickListener(this) ,  
 ivCircularUserProfilePicture.setOnClickListener(this) at DashboardActivity.kt 
<!--Please Add Summary of the changes that you have made.-->

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
