### PR TITLE
Fix: SwipeRefreshLayout spinning endlessly on the account section

### DIFF
--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/accounts/AccountsFragment.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/accounts/AccountsFragment.kt
@@ -115,33 +115,17 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         super.onViewCreated(view, savedInstanceState)
         val layoutManager = LinearLayoutManager(activity)
         layoutManager.orientation = LinearLayoutManager.VERTICAL
-//        rv_accounts.layoutManager = layoutManager
-//        rv_accounts.setHasFixedSize(true)
-//        rv_accounts.addItemDecoration(DividerItemDecoration(activity,
-//                layoutManager.orientation))
-        rv_accounts.apply{
-            this.layoutManager=layoutManager
-            setHasFixedSize(true)
-            addItemDecoration(DividerItemDecoration(activity,
+        rv_accounts.layoutManager = layoutManager
+        rv_accounts.setHasFixedSize(true)
+        rv_accounts.addItemDecoration(DividerItemDecoration(activity,
                 layoutManager.orientation))
-        }
         btn_try_again.setOnClickListener { retry() }
         swipe_container.setOnRefreshListener(this)
 
-        loadApdaterData()
-        when (accountType) {
-            ConstantKeys.LOAN_ACCOUNTS -> {
-                rv_accounts.adapter = loanAccountsListAdapter
-                loanAccountsListAdapter.setOnItemClickListener(this)
-            }
-            ConstantKeys.DEPOSIT_ACCOUNTS -> {
-                rv_accounts.adapter = depositAccountListAdapter
-                depositAccountListAdapter.setOnItemClickListener(this)
-            }
-        }
+        loadAdapterData()
     }
 
-    private fun loadApdaterData() {
+    private fun loadAdapterData() {
         when (accountType) {
             ConstantKeys.LOAN_ACCOUNTS -> {
                 rv_accounts.adapter = loanAccountsListAdapter
@@ -283,7 +267,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
     }
 
     override fun onRefresh() {
-        loadApdaterData()
+        loadAdapterData()
         swipe_container.isRefreshing =false
     }
 

--- a/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/accounts/AccountsFragment.kt
+++ b/app/src/main/kotlin/org/mifos/mobile/cn/ui/mifos/accounts/AccountsFragment.kt
@@ -1,14 +1,15 @@
 package org.mifos.mobile.cn.ui.mifos.accounts
 
 import android.os.Bundle
-import android.util.Log
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler
 import kotlinx.android.synthetic.main.fragment_accounts.*
+import kotlinx.android.synthetic.main.layout_exception_handler.*
 import org.mifos.mobile.cn.R
 import org.mifos.mobile.cn.data.models.accounts.deposit.DepositAccount
 import org.mifos.mobile.cn.data.models.accounts.loan.LoanAccount
@@ -19,7 +20,7 @@ import org.mifos.mobile.cn.ui.base.MifosBaseFragment
 import org.mifos.mobile.cn.ui.utils.ConstantKeys
 import org.mifos.mobile.cn.ui.utils.Network
 import javax.inject.Inject
-import kotlinx.android.synthetic.main.layout_sweet_exception_handler.*
+//import kotlinx.android.synthetic.main.layout_sweet_exception_handler.*
 import org.mifos.mobile.cn.data.models.CheckboxStatus
 import org.mifos.mobile.cn.ui.base.OnItemClickListener
 import org.mifos.mobile.cn.ui.mifos.customerDepositDetails.CustomerDepositDetailsFragment
@@ -28,10 +29,11 @@ import org.mifos.mobile.cn.ui.utils.RxBus
 import org.mifos.mobile.cn.ui.utils.RxEvent
 
 
-class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClickListener {
+class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClickListener, SwipeRefreshLayout.OnRefreshListener {
 
 
     private lateinit var accountType: String
+
     private lateinit var loanAccounts: List<LoanAccount>
     private lateinit var depositAccounts: List<DepositAccount>
     var currentFilterList: List<CheckboxStatus>? = null
@@ -113,12 +115,33 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         super.onViewCreated(view, savedInstanceState)
         val layoutManager = LinearLayoutManager(activity)
         layoutManager.orientation = LinearLayoutManager.VERTICAL
-        rv_accounts.layoutManager = layoutManager
-        rv_accounts.setHasFixedSize(true)
-        rv_accounts.addItemDecoration(DividerItemDecoration(activity,
+//        rv_accounts.layoutManager = layoutManager
+//        rv_accounts.setHasFixedSize(true)
+//        rv_accounts.addItemDecoration(DividerItemDecoration(activity,
+//                layoutManager.orientation))
+        rv_accounts.apply{
+            this.layoutManager=layoutManager
+            setHasFixedSize(true)
+            addItemDecoration(DividerItemDecoration(activity,
                 layoutManager.orientation))
+        }
         btn_try_again.setOnClickListener { retry() }
+        swipe_container.setOnRefreshListener(this)
 
+        loadApdaterData()
+        when (accountType) {
+            ConstantKeys.LOAN_ACCOUNTS -> {
+                rv_accounts.adapter = loanAccountsListAdapter
+                loanAccountsListAdapter.setOnItemClickListener(this)
+            }
+            ConstantKeys.DEPOSIT_ACCOUNTS -> {
+                rv_accounts.adapter = depositAccountListAdapter
+                depositAccountListAdapter.setOnItemClickListener(this)
+            }
+        }
+    }
+
+    private fun loadApdaterData() {
         when (accountType) {
             ConstantKeys.LOAN_ACCOUNTS -> {
                 rv_accounts.adapter = loanAccountsListAdapter
@@ -135,15 +158,15 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         when (accountType) {
             ConstantKeys.LOAN_ACCOUNTS -> {
                 (activity as MifosBaseActivity).replaceFragment(
-                        CustomerLoanDetailsFragment.newInstance(
-                                loanAccounts[position].productIdentifier!!,
-                                loanAccounts[position].identifier!!), true, R.id.container)
+                    CustomerLoanDetailsFragment.newInstance(
+                        loanAccounts[position].productIdentifier!!,
+                        loanAccounts[position].identifier!!), true, R.id.container)
             }
             ConstantKeys.DEPOSIT_ACCOUNTS -> {
                 (activity as MifosBaseActivity).replaceFragment(
-                        CustomerDepositDetailsFragment.newInstance(
-                                depositAccounts[position].accountIdentifier!!),true,R.id.container
-                                )
+                    CustomerDepositDetailsFragment.newInstance(
+                        depositAccounts[position].accountIdentifier!!),true,R.id.container
+                )
             }
         }
     }
@@ -163,6 +186,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
     /**
      * Shows [List] of [LoanAccount] fetched from server using
      * [LoanAccountListAdapter]
+
      * @param loanAccounts [List] of [LoanAccount]
      */
     override fun showLoanAccounts(loanAccounts: List<LoanAccount>) {
@@ -178,12 +202,12 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         when (feature) {
             getString(R.string.loan) -> {
                 errorHandler.showSweetEmptyUI(feature, R.drawable.ic_payment_black_24dp, rv_accounts,
-                        layout_error)
+                    layout_error)
             }
 
             getString(R.string.deposit) ->
                 errorHandler.showSweetEmptyUI(feature, R.drawable.ic_monetization_on_black_24dp,
-                        rv_accounts, layout_error)
+                    rv_accounts, layout_error)
         }
 
     }
@@ -211,7 +235,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         val filteredLoans = java.util.ArrayList<LoanAccount>()
         for (status in accountsPresenter.getCheckedStatus(statusModelList)) {
             filteredLoans.addAll(accountsPresenter.getFilteredLoanAccount(loanAccounts,
-                    status))
+                status))
         }
         loanAccountsListAdapter.setCustomerLoanAccounts(filteredLoans)
     }
@@ -220,7 +244,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
         val filteredDeposit = ArrayList<DepositAccount>()
         for (status in accountsPresenter.getCheckedStatus(statusModelList)) {
             filteredDeposit.addAll(accountsPresenter.getFilteredDepositAccount(depositAccounts,
-                    status))
+                status))
             depositAccountListAdapter.setCustomerDepositAccounts(filteredDeposit)
         }
     }
@@ -232,7 +256,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
      */
     fun searchLoanAccount(input: String) {
         loanAccountsListAdapter.setCustomerLoanAccounts(accountsPresenter
-                .searchInLoanList(loanAccounts, input))
+            .searchInLoanList(loanAccounts, input))
     }
 
     /**
@@ -242,7 +266,7 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
      */
     fun searchDepositAccount(input: String) {
         depositAccountListAdapter.setCustomerDepositAccounts(accountsPresenter
-                .searchInDepositList(depositAccounts, input))
+            .searchInDepositList(depositAccounts, input))
     }
 
 
@@ -256,6 +280,11 @@ class AccountsFragment : MifosBaseFragment(), AccountsContract.View, OnItemClick
             ConstantKeys.LOAN_ACCOUNTS -> accountsPresenter.loadLoanAccounts()
             ConstantKeys.DEPOSIT_ACCOUNTS -> accountsPresenter.loadDepositAccounts()
         }
+    }
+
+    override fun onRefresh() {
+        loadApdaterData()
+        swipe_container.isRefreshing =false
     }
 
     override fun showProgress() {


### PR DESCRIPTION
## Issue Fix
Fixes #216 

## Screenshots
https://user-images.githubusercontent.com/70816971/110118007-b69f3c00-7ddf-11eb-8081-7f553c8fab60.mp4

## Description
Added code to stop the continuous spinning of SwipeRefreshLayout in account section and also added the action, it is supposed to do when refresh layout

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [ x ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.
